### PR TITLE
add warning for FoodType

### DIFF
--- a/index.php
+++ b/index.php
@@ -122,7 +122,7 @@
           <input type="text" name="description" id="description" class="form-control" autocomplete="off" />
           <span id="valid_description"></span>
           <br />
-          <label>Food Type</label>
+          <label>Food Type</label> <span id="foodTypeWarning" style="color:red;"></span>
           <select name = "foodtype" id="foodtype" class ="form-control">
             <?php
               $result     = mysqli_query($connect,$query);
@@ -266,7 +266,8 @@ $(document).ready(function(){
     $('#user_id').val(user_id);
     var food_type=$('#foodtype').val();
     var product_image = $('#image_location').val();
-    
+
+    $('#foodTypeWarning').text("");  
     if(user_id !='' && description != '' && quantity != '' && food_type != 0) {
       $.ajax({
         url:"insert.php",
@@ -289,9 +290,12 @@ $(document).ready(function(){
         }
       });
     }
+    else if (food_type == 0){
+       $('#foodTypeWarning').text("Please select the food type"); 
+    }
     else
     {
-      alert("Please fill in the UPC, Description, Quantity and select the food type");
+      alert("Please fill in the UPC, Description, and Quantity");
     }
   });
 	


### PR DESCRIPTION
As the person updating inventory, it's common to forget to enter the Food Type. I sometimes miss doing that, dismiss the generic pop up box which says "Please fill in the UPC, Description, Quantity and select the food type" and then click the Close button. This results in me losing everything I've entered and possibly not realizing my data did not go in. Rather than have it pop up a generic message to fill in all fields, it would be nice if red text appeared next to the field not filled out (which like is the Food Type field).